### PR TITLE
Incorporate env vars into the configuration.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/DEFRA/os-places-address-lookup && cd os-places-addr
 
 ## Configuration
 
-The file *configuration.yml* represents a template configuration. If you are happy to use the defaults the only value you'll need to replace is `WCRS_ADDRESS_OSPLACES_KEY`.
+The file *configuration.yml* represents a template configuration. If you are happy to use the defaults the only value you'll need to replace is `WCRS_OSPLACES_KEY`.
 
 ## Build
 
@@ -43,8 +43,8 @@ Currently the unit tests included in the project rely on an actual connection to
 
 Also the unit tests cannot read from the [configuration.yml](configuration.yml) as the app would when started, so you must set some environment variables before attempting to run the tests
 
-- `WCRS_ADDRESS_OSPLACES_KEY`
-- `WCRS_ADDRESS_OSPLACES_URL`
+- `WCRS_OSPLACES_KEY`
+- `WCRS_OSPLACES_URL`
 
 For these reasons we have configured Maven not to automatically run tests when a build takes place. Instead those working on the project should manually run the tests as and when required
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -1,7 +1,4 @@
 # http://www.dropwizard.io/1.3.1/docs/manual/configuration.html#man-configuration
-#---------------------------------------
-# Server configuration
-#---------------------------------------
 server:
   applicationConnectors:
     - type: http
@@ -9,22 +6,19 @@ server:
   adminConnectors:
     - type: http
       port: 9191
-#---------------------------------------
-# Logging configuration
-#---------------------------------------
+
 logging:
   level: INFO
-
-  loggers:
-    io.dropwizard: INFO
-    
   appenders:
     - type: console
-      
-#---------------------------------------
-# Application properties
-#---------------------------------------
+      timeZone: UTC
+    - type: file
+      currentLogFilename: ${WCRS_ADDR_LOOKUP_LOGFILE:-/srv/java/os-places-address-lookup/logs/run.log}
+      archivedLogFilenamePattern: ${WCRS_ADDR_LOOKUP_LOGFILE_PATTERN:-/srv/java/os-places-address-lookup/logs/run-archive-%d.log.gz}
+      archivedFileCount: 5
+      timeZone: UTC
+
 properties:
-  key: WCRS_ADDRESS_OSPLACES_KEY
+  key: ${WCRS_OSPLACES_KEY}
   url: "https://api.ordnancesurvey.co.uk/places/v1/addresses"
   delimiter: ","

--- a/src/main/java/uk/gov/ea/address/services/AddressLookupApplication.java
+++ b/src/main/java/uk/gov/ea/address/services/AddressLookupApplication.java
@@ -3,6 +3,8 @@ package uk.gov.ea.address.services;
 import java.util.Map;
 
 import io.dropwizard.Application;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
@@ -22,9 +24,14 @@ public class AddressLookupApplication extends Application<AddressLookupConfigura
     private static Logger logger = LoggerFactory.getLogger(AddressLookupApplication.class);
 
     @Override
-    public void initialize(Bootstrap<AddressLookupConfiguration> arg0)
+    public void initialize(Bootstrap<AddressLookupConfiguration> bootstrap)
     {
-
+        bootstrap.setConfigurationSourceProvider(
+                new SubstitutingSourceProvider(
+                        bootstrap.getConfigurationSourceProvider(),
+                        new EnvironmentVariableSubstitutor(false)
+                )
+        );
     }
 
     public static void main(String[] args) throws Exception

--- a/src/test/java/uk/gov/ea/address/services/AddressLookupApplicationTest.java
+++ b/src/test/java/uk/gov/ea/address/services/AddressLookupApplicationTest.java
@@ -35,8 +35,8 @@ public class AddressLookupApplicationTest
     public void init()
     {
         MockitoAnnotations.initMocks(this);
-        key = System.getenv("WCRS_ADDRESS_OSPLACES_KEY");
-        url = System.getenv("WCRS_ADDRESS_OSPLACES_URL");
+        key = System.getenv("WCRS_OSPLACES_KEY");
+        url = System.getenv("WCRS_OSPLACES_URL");
         application = new AddressLookupApplication();
     }
 

--- a/src/test/java/uk/gov/ea/address/services/util/OSPlacesAddressSearchTest.java
+++ b/src/test/java/uk/gov/ea/address/services/util/OSPlacesAddressSearchTest.java
@@ -24,8 +24,8 @@ public class OSPlacesAddressSearchTest
     @Before
     public void init()
     {
-        key = System.getenv("WCRS_ADDRESS_OSPLACES_KEY");
-        url = System.getenv("WCRS_ADDRESS_OSPLACES_URL");
+        key = System.getenv("WCRS_OSPLACES_KEY");
+        url = System.getenv("WCRS_OSPLACES_URL");
         osPlacesAddressSearchImpl = new OSPlacesAddressSearchImpl(url, key, delimiter);
     }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-159

To improve how the service can be deployed rather than have to hard code the OS Places API key into a config file (and then have to store that config file somewhere) we've taken advantage of the upgrade in the Dropwizard framework to use environment variable substitution.

Now when the app is deployed you must provide the OS Places key in an env var called WCRS_OSPLACES_KEY.The log files will default to where they would go on our vagrant build, but this can be overridden.