### PR TITLE
Fix issue with artifact and proj name diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ jdk:
 
 env:
   global:
-    # WCRS_ADDRESS_OSPLACES_KEY
-    - secure: "Ro6iANaY8RqnaxUZOIsBqQg3QFJ0UFZ+Z0TBwGSOoFMY8lqBOqXWGeDf0gd/ErqS9w5VU1GgJ+Y080bU76nVqxU2I0HBfjOiL+ah6NbSxN8W0hMshlbLBbDlc8kgnfM39IboSmNve5MZWUQ0D+TfiUOXHm+HZD2+RUxY7K7CudQ="
-    - WCRS_ADDRESS_OSPLACES_URL="https://api.ordnancesurvey.co.uk/places/v1/addresses"
+    # WCRS_OSPLACES_KEY
+    - secure: "dMlpKaW5J9WU9aQ7LrpaAl+gfVk3Ie8Yz6t4I93zVjJ9w2RyPOpuK9Nzvj8Lw6gQaA4pmM1Lda5yC06uD0+desOIS+tv6+3Zb/HOvlbXKe6DzvAOM505ODU2hS89oce1/d3TRi7UAwy1TLdDm9P2IjHMWHdOWE1yzsQCrF/3rKc="
+    - WCRS_OSPLACES_URL="https://api.ordnancesurvey.co.uk/places/v1/addresses"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OS places address lookup
+# OS Places address lookup
 
 [![Build Status](https://travis-ci.org/DEFRA/os-places-address-lookup.svg?branch=master)](https://travis-ci.org/DEFRA/os-places-address-lookup)
 
@@ -57,7 +57,7 @@ For these reasons we have configured Maven not to automatically run tests when a
 Once built execute the jar file, providing 'server' and the name of the configuration file as arguments.
 
 ```bash
-java -jar target/address-lookup-osplaces-*.jar server configuration.yml
+java -jar target/os-places-address-lookup-*.jar server configuration.yml
 ```
 
 Once the application server is started you should be able to access the service in your browser. Confirm this by going to [http://localhost:9191](http://localhost:9191) and the operational menu will be visible.

--- a/pom.xml
+++ b/pom.xml
@@ -2,16 +2,16 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>uk.gov.ea</groupId>
-	<artifactId>address-lookup-osplaces</artifactId>
-	<version>0.1.1</version>
-	<name>osplaces-address-lookup</name>
+	<artifactId>os-places-address-lookup</artifactId>
+	<version>0.2.0</version>
+	<name>os-places-address-lookup</name>
 	<description>Provides a RESTful API for the address lookup using OSPlaces</description>
 	<properties>
 		<slf4j.version>1.7.6</slf4j.version>
 		<dropwizard.version>1.3.1</dropwizard.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.test.skip>true</maven.test.skip>
+		<maven.test.skip>false</maven.test.skip>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/uk/gov/ea/address/services/AddressLookupApplication.java
+++ b/src/main/java/uk/gov/ea/address/services/AddressLookupApplication.java
@@ -19,7 +19,7 @@ import uk.gov.ea.address.services.util.OSPlacesAddressSearchImpl;
 
 public class AddressLookupApplication extends Application<AddressLookupConfiguration>
 {
-    private static final String APPLICATION_NAME = "address-lookup-osplaces";
+    private static final String APPLICATION_NAME = "os-places-address-lookup";
 
     private static Logger logger = LoggerFactory.getLogger(AddressLookupApplication.class);
 

--- a/src/test/java/uk/gov/ea/address/services/AddressLookupApplicationTest.java
+++ b/src/test/java/uk/gov/ea/address/services/AddressLookupApplicationTest.java
@@ -44,7 +44,7 @@ public class AddressLookupApplicationTest
     public void testGetName()
     {
         Assert.assertNotNull(application.getName());
-        Assert.assertEquals("address-lookup-osplaces", application.getName());
+        Assert.assertEquals("os-places-address-lookup", application.getName());
     }
 
     @Test


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-159

There has always been a disconnect between the name of the project and the name of the fat jar it generates when built.

As we are about to move it to a new environment we are taking this opportunity to fix the difference between the two.