### PR TITLE
Remove skip test in pom.xml & use cmd arg instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ env:
     # WCRS_OSPLACES_KEY
     - secure: "dMlpKaW5J9WU9aQ7LrpaAl+gfVk3Ie8Yz6t4I93zVjJ9w2RyPOpuK9Nzvj8Lw6gQaA4pmM1Lda5yC06uD0+desOIS+tv6+3Zb/HOvlbXKe6DzvAOM505ODU2hS89oce1/d3TRi7UAwy1TLdDm9P2IjHMWHdOWE1yzsQCrF/3rKc="
     - WCRS_OSPLACES_URL="https://api.ordnancesurvey.co.uk/places/v1/addresses"
+
+script: ./mvnw -B -Dmaven.test.skip=true -T 1C clean package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,13 @@ pipeline {
     stages {
         stage('Build project artifacts') {
             steps {
-                sh "./mvnw -B -DskipTests=true -T 1C clean package"
+                // Options are
+                // -B: Run in non-interactive (batch) mode
+                // -D: Define a system property (in this case skip compiling and running tests
+                // -T 1C: Thread count which means run single threaded
+                // clean: remove files from a previous build
+                // package: take the compiled code and package it into a fat JAR
+                sh "./mvnw -B -Dmaven.test.skip=true -T 1C clean package"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The project uses [Maven](https://maven.apache.org/) as its build tool, and [Mave
 So to build the project call
 
 ```bash
-./mvnw clean package
+./mvnw -B -Dmaven.test.skip=true -T 1C clean package
 ```
 
-The normal command on a machine where Maven is installed is `mvn clean package`.
+N.B. If maven was installed all on the machine you would swap `./mvnw` with `mvn`.
 
 ## Run tests
 
@@ -46,7 +46,7 @@ Also the unit tests cannot read from the [configuration.yml](configuration.yml) 
 - `WCRS_OSPLACES_KEY`
 - `WCRS_OSPLACES_URL`
 
-For these reasons we have configured Maven not to automatically run tests when a build takes place. Instead those working on the project should manually run the tests as and when required
+Hence the command to build above includes the option to skip tests. Instead we advise those working on the project should manually run the tests as and when required using
 
 ```bash
 ./mvnw test

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 		<dropwizard.version>1.3.1</dropwizard.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.test.skip>false</maven.test.skip>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Because the project requires an actual connection to OS Places in order to run the build, this can make it a problem in CI and Jenkins jobs where that access may not be available.

So to prevent issues when building we added a skip test flag to the pom.xml, however we then found we could not get `mvn test` to run either.

Plus expected behaviour is that the tests would automatically run hence we've decided to update the project to remove the flag and instead use a command line option to govern when whether tests should be run as part of a build.

This makes it more explicit and ensures the project behaves as expected.