### PR TITLE
Update env var names used in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
                 // -T 1C: Thread count which means run single threaded
                 // clean: remove files from a previous build
                 // package: take the compiled code and package it into a fat JAR
-                sh "./mvnw -Dhttp.proxyPort=${http_proxy_port} -Dhttps.proxyPort=${https_proxy_port} -Dhttps.proxyHost=${https_proxy} -Dhttp.proxyHost=${http_proxy} -B -Dmaven.test.skip=true -T 1C clean package"
+                sh "./mvnw -Dhttp.proxyPort=${proxy_port} -Dhttps.proxyPort=${proxy_port} -Dhttps.proxyHost=${http_host} -Dhttp.proxyHost=${http_host} -B -Dmaven.test.skip=true -T 1C clean package"
             }
         }
     }


### PR DESCRIPTION
Because we were using the standard proxy names we were overwriting what those env vars should be set to.

Hence we have chosen to use different names for the env vars our script needs.