### PR TITLE
Update Travis-CI badge url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OS Places address lookup
 
-[![Build Status](https://travis-ci.org/DEFRA/os-places-address-lookup.svg?branch=master)](https://travis-ci.org/DEFRA/os-places-address-lookup)
+[![Build Status](https://travis-ci.com/DEFRA/os-places-address-lookup.svg?branch=master)](https://travis-ci.com/DEFRA/os-places-address-lookup)
 
 A REST based wrapper built using [Dropwizard](http://dropwizard.io/) around the [OS Places API](http://www.ordnancesurvey.co.uk/business-and-government/products/os-places/index.html).
 


### PR DESCRIPTION
The project has been migrated from travis-ci.org to travis-ci.com so updating the url behind the badge to reflect this.