### PR TITLE
Add support for test coverage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
     - secure: "dMlpKaW5J9WU9aQ7LrpaAl+gfVk3Ie8Yz6t4I93zVjJ9w2RyPOpuK9Nzvj8Lw6gQaA4pmM1Lda5yC06uD0+desOIS+tv6+3Zb/HOvlbXKe6DzvAOM505ODU2hS89oce1/d3TRi7UAwy1TLdDm9P2IjHMWHdOWE1yzsQCrF/3rKc="
     - WCRS_OSPLACES_URL="https://api.ordnancesurvey.co.uk/places/v1/addresses"
 
-script: ./mvnw -B -Dmaven.test.skip=true -T 1C clean package
+script: ./mvnw clean test

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,40 @@
 		<finalName>${project.artifactId}</finalName>
 		<plugins>
 			<plugin>
+				<!-- Configuration based on https://www.mkyong.com/maven/jacoco-java-code-coverage-maven-example/ -->
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.2</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<dataFile>target/jacoco.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>target/jacoco</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>


### PR DESCRIPTION
This project has tests, and is hooked up to Travis-CI. However, it has never produced details on the level of test coverage.

With the move to hook all our projects to [SonarCloud](https://sonarcloud.io/organizations/defra/projects) we have decided to take this opportunity to add support to generate test coverage, so we can display it in SonarCloud.