### PR TITLE
Rename agent label in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Requires the Workspace Cleanup Plugin to be installed before use
 // https://jenkins.io/doc/pipeline/steps/ws-cleanup/
 pipeline {
-    agent { label 'master' }
+    agent { label 'main' }
     stages {
         stage('Build project artifacts') {
             steps {


### PR DESCRIPTION
[Scott Hanselman](https://www.hanselman.com/about/) explains the reasoning for this even better than I can

> The [Internet Engineering Task Force (IETF) points out](https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.1.1) that "Master-slave is an oppressive metaphor that will and should never become fully detached from history" as well as "In addition to being inappropriate and arcane, the [master-slave metaphor](https://github.com/bitkeeper-scm/bitkeeper/blob/master/doc/HOWTO.ask?WT.mc_id=-blog-scottha#L231-L232) is both technically and historically inaccurate." There's lots of more accurate options depending on context and it costs me nothing to change my vocabulary, especially if it is one less little speed bump to getting a new person excited about tech.

Reference [Easily rename your Git default branch from master to main - Scott Hanselman](https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx)

The [ruby-services-team](https://github.com/DEFRA/ruby-services-team) has been going through its repos updating all to use `main` as the primary branch. Whilst doing so we spotted this reference to 'master' in the Jenkinsfile. So also taking the opportunity to rename that as well.