### PR TITLE
Revert "Rename agent label in Jenkinsfile"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Requires the Workspace Cleanup Plugin to be installed before use
 // https://jenkins.io/doc/pipeline/steps/ws-cleanup/
 pipeline {
-    agent { label 'main' }
+    agent { label 'master' }
     stages {
         stage('Build project artifacts') {
             steps {


### PR DESCRIPTION
Reverts DEFRA/os-places-address-lookup#24

Looks like our Jenkins server may depend on this label so it's going to take some extra work to remove the use of it.