### PR TITLE
Update OS Places API endpoint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"

--- a/configuration.yml
+++ b/configuration.yml
@@ -20,7 +20,7 @@ logging:
 
 properties:
   key: ${WCRS_OSPLACES_KEY}
-  url: "https://api.ordnancesurvey.co.uk/places/v1/addresses"
+  url: "https://api.os.uk/search/places/v1"
   # If enabled the service will not call OS Places and instead read previously
   # recorded results from JSON files in resources
   mock: ${WCRS_MOCK_ENABLED:-false}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1244

The URL for OS Places is changing so we need to update the URL and the key.